### PR TITLE
Added Cairo library wrapper Cairocffi

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from colour import Color
 from poisson_disc import poisson_disc
 from shapely.geometry import Polygon, MultiPolygon, Point
 from xkcd import xkcdify
-import cairo
+import cairocffi as cairo
 import graph
 import layers
 import math

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ noise==1.2.2
 pyhull==1.5.6
 Pillow==3.0.0
 colour==0.1.2
+cairocffi==0.8.0


### PR DESCRIPTION
Hi there - I'm really enjoying going through your projects and learning from them! 

Regarding this PR: this project requires Cairo and I was unable to install a Cairo wrapper in a virtual env. If a user wants to install Cairo in a virtualenv there's a few small steps to take, but I prefer to use `pip` when possible. If you'd like to make it easy for people to run this code in a virtualenv please feel free to merge this PR.

Cairocffi is a replacement for pycairo that installs with pip in a virtual environment, runs on Python 2 and 3, as well as PyPy. It is nicely documented [here](http://cairocffi.readthedocs.io/en/latest/).